### PR TITLE
resolve git conflicts with Xcode project file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.pbxproj merge=union
+


### PR DESCRIPTION
Automatically resolving git merge conflicts in Xcode’s `project.pbxproj` file